### PR TITLE
Notification service - make dbModels optional

### DIFF
--- a/lib/notifications.js
+++ b/lib/notifications.js
@@ -45,10 +45,6 @@ module.exports = ({ mqConfiguration = {}, dbModels = {}, pingMessage }) => {
     throw new Error('Missing MQ configuration');
   }
 
-  const { Badge } = dbModels;
-
-  if (!Badge) throw new Error('Badge model is not provided');
-
   const logger = buildLogger({});
 
   /**
@@ -178,6 +174,9 @@ module.exports = ({ mqConfiguration = {}, dbModels = {}, pingMessage }) => {
    * @param {Object} [wallet] The wallet object from the recipient user
    */
   const createBadgesNotification = async (wallet, type) => {
+    const { Badge } = dbModels;
+    if (!Badge) throw new Error('Badge model is not provided');
+
     let badgeObject;
 
     logger.info(`Attempting to get the ${type} badge object`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pillarwallet/common-services",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pillarwallet/common-services",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pillarwallet/common-services",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "A module that provides access to common services.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pillarwallet/common-services",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "description": "A module that provides access to common services.",
   "main": "index.js",
   "scripts": {

--- a/tests/unit/notificationService.spec.js
+++ b/tests/unit/notificationService.spec.js
@@ -36,8 +36,6 @@ describe('Notification Service', () => {
     payload: {},
   };
 
-  const Badge = jest.fn();
-
   beforeEach(() => {
     mqConfiguration = {
       topic: 'topic',
@@ -65,7 +63,7 @@ describe('Notification Service', () => {
   it('should return the Notification Service instance', () => {
     const NotificationService = buildNotificationService({
       mqConfiguration,
-      dbModels: { Badge },
+      dbModels: {},
       pingMessage: false,
     });
 
@@ -84,14 +82,8 @@ describe('Notification Service', () => {
     );
   });
 
-  it('should fail on invalid params, missing Badge model', () => {
-    expect(() => buildNotificationService({ mqConfiguration, dbModels: {}, pingMessage: false })).toThrowError(
-      new TypeError('Badge model is not provided'),
-    );
-  });
-
   it('should have called the node-cron scheduler function if pingMessage is true', async () => {
-    buildNotificationService({ mqConfiguration, dbModels: { Badge }, pingMessage: true });
+    buildNotificationService({ mqConfiguration, dbModels: {}, pingMessage: true });
 
     expect(cron.CronJob).toHaveBeenCalledWith({
       cronTime: '* * * * *',
@@ -104,12 +96,12 @@ describe('Notification Service', () => {
   });
 
   it('should not have called the node-cron scheduler function if pingMessage is false', async () => {
-    buildNotificationService({ mqConfiguration, dbModels: { Badge }, pingMessage: false });
+    buildNotificationService({ mqConfiguration, dbModels: {}, pingMessage: false });
     expect(cron.CronJob).not.toBeCalled();
   });
 
   it('should have instantiated a new MQ with the correct config options', () => {
-    buildNotificationService({ mqConfiguration, dbModels: { Badge }, pingMessage: false });
+    buildNotificationService({ mqConfiguration, dbModels: {}, pingMessage: false });
 
     const amqpCallParameter1 = AMQP.mock.calls[0][0];
     const amqpCallParameter2 = AMQP.mock.calls[0][1];
@@ -136,7 +128,7 @@ describe('Notification Service', () => {
       frameMax: 1,
       heartbeat: 2,
     };
-    buildNotificationService({ mqConfiguration, dbModels: { Badge }, pingMessage: false });
+    buildNotificationService({ mqConfiguration, dbModels: {}, pingMessage: false });
     const amqpCallParameter1 = AMQP.mock.calls[0][0];
     const amqpCallParameter2 = AMQP.mock.calls[0][1];
     const amqpCallParameter3 = AMQP.mock.calls[0][2];
@@ -150,7 +142,7 @@ describe('Notification Service', () => {
   });
 
   it('should have instantiated a new MQ with the correct config options, PING', () => {
-    buildNotificationService({ mqConfiguration, dbModels: { Badge }, pingMessage: true });
+    buildNotificationService({ mqConfiguration, dbModels: {}, pingMessage: true });
     const amqpCallParameter1 = AMQP.mock.calls[1][0];
     const amqpCallParameter2 = AMQP.mock.calls[1][1];
     const amqpCallParameter3 = AMQP.mock.calls[1][2];
@@ -164,7 +156,7 @@ describe('Notification Service', () => {
   });
 
   it('should have called the node-cron scheduler function', async () => {
-    buildNotificationService({ mqConfiguration, dbModels: { Badge }, pingMessage: true });
+    buildNotificationService({ mqConfiguration, dbModels: {}, pingMessage: true });
     expect(cron.CronJob).toHaveBeenCalledWith({
       cronTime: '* * * * *',
       onTick: expect.any(Function),


### PR DESCRIPTION
Make dbModels optional to be able to consume the service from Archanova platform without passing the Badges model (and importing common-models to archanova when it's not necessary).