### PR TITLE
Add Referral type badges

### DIFF
--- a/lib/badges.js
+++ b/lib/badges.js
@@ -159,6 +159,96 @@ module.exports = ({ loggerPath = '', logToFile = false, dbModels = {} }) => {
     awardOnce(walletId, userId, types.FIRST_TRANSACTION_RECEIVED_TYPE);
 
   /**
+   * @name onEmailVerified
+   * @description Method that awards user with a badge for the first email verification
+   *
+   * @param {String} [walletId] Wallet ID
+   * @param {String} [userId] User ID
+   *
+   * @returns Promise<MongoDBObject>
+   */
+  const onEmailVerified = (walletId, userId) => awardOnce(walletId, userId, types.EMAIL_VERIFIED_TYPE);
+
+  /**
+   * @name onPhoneVerified
+   * @description Method that awards user with a badge for the first phone verification
+   *
+   * @param {String} [walletId] Wallet ID
+   * @param {String} [userId] User ID
+   *
+   * @returns Promise<MongoDBObject>
+   */
+  const onPhoneVerified = (walletId, userId) => awardOnce(walletId, userId, types.PHONE_VERIFIED_TYPE);
+
+  /**
+   * @name onReferralRewardReceived
+   * @description Method that awards user with a badge for the first referral reward received
+   *
+   * @param {String} [walletId] Wallet ID
+   * @param {String} [userId] User ID
+   *
+   * @returns Promise<MongoDBObject>
+   */
+  const onReferralRewardReceived = (walletId, userId) =>
+    awardOnce(walletId, userId, types.REFERRAL_REWARD_RECEIVED_TYPE);
+
+  /**
+   * @name onReferralInviteSent1
+   * @description Method that awards user with a badge for the first referral invite sent
+   *
+   * @param {String} [walletId] Wallet ID
+   * @param {String} [userId] User ID
+   *
+   * @returns Promise<MongoDBObject>
+   */
+  const onReferralInviteSent1 = (walletId, userId) => awardOnce(walletId, userId, types.REFERRAL_INVITE_SENT_1_TYPE);
+
+  /**
+   * @name onReferralInviteSent5
+   * @description Method that awards user with a badge for the first five referral invites sent
+   *
+   * @param {String} [walletId] Wallet ID
+   * @param {String} [userId] User ID
+   *
+   * @returns Promise<MongoDBObject>
+   */
+  const onReferralInviteSent5 = (walletId, userId) => awardOnce(walletId, userId, types.REFERRAL_INVITE_SENT_5_TYPE);
+
+  /**
+   * @name onReferralInviteSent10
+   * @description Method that awards user with a badge for the first ten referral invites sent
+   *
+   * @param {String} [walletId] Wallet ID
+   * @param {String} [userId] User ID
+   *
+   * @returns Promise<MongoDBObject>
+   */
+  const onReferralInviteSent10 = (walletId, userId) => awardOnce(walletId, userId, types.REFERRAL_INVITE_SENT_10_TYPE);
+
+  /**
+   * @name onReferralInviteSent25
+   * @description Method that awards user with a badge for the first twenty five referral invites sent
+   *
+   * @param {String} [walletId] Wallet ID
+   * @param {String} [userId] User ID
+   *
+   * @returns Promise<MongoDBObject>
+   */
+  const onReferralInviteSent25 = (walletId, userId) => awardOnce(walletId, userId, types.REFERRAL_INVITE_SENT_25_TYPE);
+
+  /**
+   * @name onReferralInviteSent100
+   * @description Method that awards user with a badge for the first hundred referral invites sent
+   *
+   * @param {String} [walletId] Wallet ID
+   * @param {String} [userId] User ID
+   *
+   * @returns Promise<MongoDBObject>
+   */
+  const onReferralInviteSent100 = (walletId, userId) =>
+    awardOnce(walletId, userId, types.REFERRAL_INVITE_SENT_100_TYPE);
+
+  /**
    * @name selfAward
    * @description Method to award yourself with a badge
    *
@@ -176,6 +266,14 @@ module.exports = ({ loggerPath = '', logToFile = false, dbModels = {} }) => {
     onConnectionEstablished,
     onTransactionMade,
     onTransactionReceived,
+    onEmailVerified,
+    onPhoneVerified,
+    onReferralRewardReceived,
+    onReferralInviteSent1,
+    onReferralInviteSent5,
+    onReferralInviteSent10,
+    onReferralInviteSent25,
+    onReferralInviteSent100,
     selfAward,
   };
 };

--- a/lib/badges.js
+++ b/lib/badges.js
@@ -52,18 +52,16 @@ module.exports = ({ loggerPath = '', logToFile = false, dbModels = {} }) => {
     try {
       badgeObject = await Badge.findOne({ type: badgeType });
     } catch (e) {
-      logger.error('An error occurred whilst getting a badge object');
-      logger.error(e);
+      logger.error(e, 'An error occurred whilst getting a badge object');
     }
     if (!badgeObject) return;
 
     // check if user was already awarded
     logger.info('Checking if our user was already awarded');
     try {
-      badgeAwardObject = await BadgeAward.findOne({ badgeType, walletId });
+      badgeAwardObject = await BadgeAward.findOne({ badgeType, userId });
     } catch (e) {
-      logger.error('An error occurred whilst getting a BadgeAward object');
-      logger.error(e);
+      logger.error(e, 'An error occurred whilst getting a BadgeAward object');
       return;
     }
 
@@ -84,7 +82,7 @@ module.exports = ({ loggerPath = '', logToFile = false, dbModels = {} }) => {
         txHash: '',
       }).save();
     } catch (e) {
-      logger.error('An error occurred whilst trying to create a BadgeAward:');
+      logger.error(e, 'An error occurred whilst trying to create a BadgeAward:');
       logger.error({
         badge: badgeObject._id, // eslint-disable-line
         badgeType,
@@ -93,7 +91,6 @@ module.exports = ({ loggerPath = '', logToFile = false, dbModels = {} }) => {
         txStatus: CONFIRMED_TX_STATUS,
         txHash: '',
       });
-      logger.error(e);
     }
     if (badgeAwardObject) {
       logger.info('User was awarded with a badge');

--- a/utilities/badgesTypes.js
+++ b/utilities/badgesTypes.js
@@ -4,4 +4,12 @@ module.exports = {
   FIRST_CONNECTION_ESTABLISHED_BADGE_TYPE: 'first-connection-established',
   FIRST_TRANSACTION_MADE_TYPE: 'first-transaction-made',
   FIRST_TRANSACTION_RECEIVED_TYPE: 'first-transaction-received',
+  EMAIL_VERIFIED_TYPE: 'email-verified',
+  PHONE_VERIFIED_TYPE: 'phone-verified',
+  REFERRAL_REWARD_RECEIVED_TYPE: 'referral-reward-received',
+  REFERRAL_INVITE_SENT_1_TYPE: 'referral-invite-sent-one',
+  REFERRAL_INVITE_SENT_5_TYPE: 'referral-invite-sent-five',
+  REFERRAL_INVITE_SENT_10_TYPE: 'referral-invite-sent-ten',
+  REFERRAL_INVITE_SENT_25_TYPE: 'referral-invite-sent-twentyfive',
+  REFERRAL_INVITE_SENT_100_TYPE: 'referral-invite-sent-hundred',
 };


### PR DESCRIPTION
- Add new Referral badge types
- Search previous badge award by userId instead of walletId (user can have multiple wallet records)